### PR TITLE
Add files via upload

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,8 +3,9 @@ const path = require('path');
 const fs = require('fs').promises;
 const axios = require('axios');
 
-const dataPath = path.join(__dirname, 'data.json');
-const apiKey = '66be4cd1e2f35b9b853f45c53503ec92da94c9951c63319dbf576893fecf497b'; // Replace with your actual API key
+// Use the app’s data folder to store data.json
+const dataPath = path.join(app.getPath('userData'), 'data.json');
+const apiKey = '66be4cd1e2f35b9b853f45c53503ec92da94c9951c63319dbf576893fecf497b';
 
 // Create data.json if it doesn't exist
 async function ensureDataFile() {
@@ -39,14 +40,14 @@ async function checkExpiryDates() {
     if (vaccine.expiryDate === today && !vaccine.reminderSent) {
       const message = `Reminder: Your pet ${vaccine.petName}'s ${vaccine.vaccinationType} vaccination has expired. Please visit the bardibas vet clinic and pet shops.`;
       await sendSMS(vaccine.ownerContact, message);
-      vaccine.reminderSent = true; // Mark the reminder as sent
+      vaccine.reminderSent = true;
       dataChanged = true;
       remindersSentToday++;
     }
   }
 
   if (dataChanged) {
-    await fs.writeFile(dataPath, JSON.stringify(data, null, 2)); // Save changes to file
+    await fs.writeFile(dataPath, JSON.stringify(data, null, 2));
   }
 
   return remindersSentToday;


### PR DESCRIPTION
Data Path Change: Instead of saving data.json in the current directory (which may be restricted on some systems), I’ve updated the code to save it in the user's app data folder using app.getPath('userData'). This ensures the app works on any computer, as this location is universally writable across different operating systems.

File Access: The file is now created in this folder if it doesn’t already exist, so when packaging and installing on other machines, it will still have proper access to read and write the data.json file.